### PR TITLE
10: bad substitution error in config script

### DIFF
--- a/bin/config.sh
+++ b/bin/config.sh
@@ -200,7 +200,7 @@ init_config()
     cp -r "${PROFILE_ROOT}/$1/scripts" "$DOCKER_ROOT/$1/"
     echo "copy ${PROFILE_ROOT}/$1/config/$_arg_environment/config to $DOCKER_ROOT/$1/"
     cp -r "${PROFILE_ROOT}/$1/config/$_arg_environment/config" "$DOCKER_ROOT/$1/"
-    jq --arg mode "${_arg_ig_mode^^}" '.mode = $mode' "$DOCKER_ROOT/$1/config/"admin.json > "$DOCKER_ROOT/$1/config/"admin.json.tmp
+    jq --arg mode "$(echo $_arg_ig_mode | tr '[:lower:]' '[:upper:]')" '.mode = $mode' "$DOCKER_ROOT/$1/config/"admin.json > "$DOCKER_ROOT/$1/config/"admin.json.tmp
     mv "$DOCKER_ROOT/$1/config/"admin.json.tmp "$DOCKER_ROOT/$1/config/"admin.json
     echo "IG mode $_arg_ig_mode"
     if [ "$_arg_ig_mode" == "development" ]; then


### PR DESCRIPTION
## Features and fixes
- Change the conversion of `IG mode` to uppercase using the `tr` command instead of the syntax `^^`
- The script convert the `IG_mode` selected by the user or the default value to uppercase because the json descriptor where is set that value require an uppercase value.
## Issue related
- Solves [Issue 10](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-demo/issues/10)